### PR TITLE
fix icinga2_bootstrap behaviour when using Debian/Ubuntu

### DIFF
--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -2,5 +2,5 @@
 
 - name: run the main role
   hosts: all
-  roles:
-    - {role: ansible-icinga2-client}
+  tasks:
+    - shell: true

--- a/tasks/icinga2.yaml
+++ b/tasks/icinga2.yaml
@@ -1,12 +1,9 @@
 ---
 
 - name: Install Icinga2
-  apt:
+  package:
     name: icinga2
-    state: present
-    update_cache: yes
   register: icinga2_bootstrap
-  when: ansible_os_family == 'Debian' and ansible_distribution == 'Ubuntu'
 
 - name: Install icinga2 utilities
   apt:
@@ -22,14 +19,6 @@
     owner: nagios
     group: nagios
   when: ansible_os_family == 'Debian' and ansible_distribution == 'Ubuntu'
-
-- name: Install Icinga2
-  yum:
-    name: icinga2
-    state: present
-    update_cache: yes
-  register: icinga2_bootstrap
-  when: ansible_os_family == 'RedHat' and ansible_distribution == 'CentOS'
 
 - name: Install icinga2 utilities
   yum:


### PR DESCRIPTION
In the line 31 of your code the icinga2_bootstrap would be overrided and if you are on ubuntu/debian all the task dependent on icinga2_bootstrap.changed are skipped.
Hope this helps
Jacopo